### PR TITLE
detectAndSaveMouths

### DIFF
--- a/process-lrw/process_lrw_functions.py
+++ b/process-lrw/process_lrw_functions.py
@@ -331,7 +331,7 @@ def extract_and_save_frames_and_mouths(saveDir=LRW_SAVE_DIR,
     for f, frame in enumerate(videoFrames):
 
         # If frames are extracted from video, all frames are read
-        if detectAndSaveMouths:
+        if extractFramesFromMp4:
             frameNumer = f + 1
         # If frames are read from jpeg images, frame numbers are in their names
         else:


### PR DESCRIPTION
If ```detectAndSaveMouths = False```, there will be a bug shown up. 
And I think the reason is the wrong conditon, we should change ```detectAndSaveMouths``` to ```extractFramesFromMp4```. 